### PR TITLE
closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ git clone
 ### Install the dependencies
 ```
 npm install
-bower install
 ```
 
 ### Create a dist version

--- a/package.json
+++ b/package.json
@@ -11,16 +11,17 @@
   },
   "scripts": {
     "test": "grunt",
-    "start": "grunt serve"
+    "start": "grunt serve",
+    "postinstall": "bower install"
   },
   "keywords": [
     "predix-app"
   ],
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "load-grunt-tasks": "^3.2.0",
+    "bower": "^1.7.1",
     "connect-modrewrite": "^0.7.9",
     "glob": "^5.0.13",
+    "grunt": "~0.4.5",
     "grunt-autoprefixer": "^3.0.3",
     "grunt-config": "^0.2.2",
     "grunt-contrib-clean": "^0.5.0",
@@ -31,8 +32,8 @@
     "grunt-contrib-requirejs": "~0.4.3",
     "grunt-contrib-watch": "~v0.6.1",
     "grunt-karma": "~0.8.2",
-    "http-rewrite-middleware": "^0.1.6",
     "grunt-vulcanize": "^1.0.0",
+    "http-rewrite-middleware": "^0.1.6",
     "json-proxy": "^0.9.1",
     "karma": "~0.12.0",
     "karma-chrome-launcher": "~0.1",
@@ -45,6 +46,7 @@
     "karma-requirejs": "^0.2.1",
     "karma-script-launcher": "~0.1.0",
     "karma-spec-reporter": "0.0.13",
+    "load-grunt-tasks": "^3.2.0",
     "open": "0.0.4",
     "phantomjs": "1.9.7-15",
     "protractor": "^1.3.1",


### PR DESCRIPTION
adding post-install npm hook to automatically install bower dependencies.
this also removes the need to have bower installed globally.