### PR TITLE
fix spell error in vulcanize config: inlineCSS -> inlineCss

### DIFF
--- a/tasks/compile.vulcanize.js
+++ b/tasks/compile.vulcanize.js
@@ -28,7 +28,7 @@ module.exports = function(gulp) {
           'public/bower_components/px-card/px-card.html'
         ],
         stripComments: true,
-        inlineCSS: true,
+        inlineCss: true,
         inlineScripts: true
       }))
       .pipe(gulp.dest('dist/public/elements/'));


### PR DESCRIPTION
Fix spell error.
This error will make css can not be inlined into html file. For example, `px-vis-timeseries-styles.html` will not be inlined into html.