### PR TITLE
Fix gulp dependency order.

### DIFF
--- a/tasks/compile.index.js
+++ b/tasks/compile.index.js
@@ -8,7 +8,7 @@ const rename = require('gulp-rename');
 
 module.exports = function(gulp) {
   return function() {
-    gulp.src('./public/_index.html')
+    return gulp.src('./public/_index.html')
       .pipe(inlinesource())
       .pipe(rename('index.html'))
       .pipe(gulp.dest('./public'));

--- a/tasks/compile.sass.js
+++ b/tasks/compile.sass.js
@@ -23,7 +23,7 @@ var styleModuleDest = function(file) {
 module.exports = function(gulp, plugins) {
   return function() {
 
-    gulp.src([
+    return gulp.src([
         './public/*.scss',
         './public/elements/*.scss',
         './public/elements/**/*.scss'


### PR DESCRIPTION
The async handle returned from 'gulp.src' needs to be returned for the dependency order defined in 'gulpfile.js' to work properly.

This resolves an issue where if the dynamically generated 'index.html' or '*-style.html' files don't already exist in '/public' then running 'gulp dist' copies the '/public' folder to '/dist/public' before those files get created.