### PR TITLE
Ability to fetch user information from UAA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 temp
 dist
 .github/
+.vscode/

--- a/server/app.js
+++ b/server/app.js
@@ -123,7 +123,18 @@ if (!uaaIsConfigured) { // no restrictions
   //Use this route to make the entire app secure.  This forces login for any path in the entire app.
   app.use('/', passport.authenticate('main', {
     noredirect: false //Don't redirect a user to the authentication page, just show an error
-    }),
+  }),
+  function (req, res, next) { //workaround to get userinfo from accesstoken
+      if (!req.user.details) {
+        userInfo(req.session.passport.user.ticket.access_token, config.uaaURL, function (userDetails) {
+          req.user.details = userDetails;
+          console.log(req.user.details);
+          next();
+        });
+      } else {
+        next();
+      }
+    },
     express.static(path.join(__dirname, process.env['base-dir'] ? process.env['base-dir'] : '../public'))
   );
 

--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,8 @@ var proxy = require('./proxy'); // used when requesting data from real services.
 var config = require('./predix-config');
 // configure passport for authentication with UAA
 var passportConfig = require('./passport-config');
+// getting user information from UAA
+var userInfo = require('./user-info');
 
 // if running locally, we need to set up the proxy from local config file:
 var node_env = process.env.node_env || 'development';
@@ -124,17 +126,7 @@ if (!uaaIsConfigured) { // no restrictions
   app.use('/', passport.authenticate('main', {
     noredirect: false //Don't redirect a user to the authentication page, just show an error
   }),
-  function (req, res, next) { //workaround to get userinfo from accesstoken
-      if (!req.user.details) {
-        userInfo(req.session.passport.user.ticket.access_token, config.uaaURL, function (userDetails) {
-          req.user.details = userDetails;
-          console.log(req.user.details);
-          next();
-        });
-      } else {
-        next();
-      }
-    },
+    userInfo(config.uaaURL),
     express.static(path.join(__dirname, process.env['base-dir'] ? process.env['base-dir'] : '../public'))
   );
 

--- a/server/user-info.js
+++ b/server/user-info.js
@@ -2,7 +2,8 @@
 //function below hits the UAA endpoint with the access token and fetches user information 
 var request = require('request');
 
-var getUserInfo = function(accessToken, uaaURL, callback){
+var getUserInfo = function (accessToken, uaaURL, callback) {
+  //console.log("Access Token: " + accessToken + "\nuaaURL: " + uaaURL);
 	var options = {
 		method: 'GET',
 		url: uaaURL + '/userinfo',
@@ -11,15 +12,28 @@ var getUserInfo = function(accessToken, uaaURL, callback){
 		}
 	};
 
-	request(options, function(err, response, body) {
-        if (!err) {
-            var userDetails = JSON.parse(body);
-            callback(userDetails);
+	request(options, function (err, response, body) {
+		if (!err) {
+			var userDetails = JSON.parse(body);
+			callback(userDetails);
 		} else {
-            console.log(response.statusCode);
+			console.log(response.statusCode);
 			console.log('ERROR fetching client token: ' + err);
 		}
 	});
 };
 
-module.exports = getUserInfo;
+module.exports = function(uaaURL){
+  return function(req, res, next){
+    if (!req.user.details){
+      getUserInfo(req.session.passport.user.ticket.access_token, uaaURL, function(userDetails){
+        console.log(userDetails);
+        req.user.details = userDetails;
+        next();
+      });
+    }
+    else{
+      next();
+    }
+  }
+};

--- a/server/user-info.js
+++ b/server/user-info.js
@@ -1,0 +1,25 @@
+//custom middleware to get the user information from the access token
+//function below hits the UAA endpoint with the access token and fetches user information 
+var request = require('request');
+
+var getUserInfo = function(accessToken, uaaURL, callback){
+	var options = {
+		method: 'GET',
+		url: uaaURL + '/userinfo',
+		headers: {
+			'Authorization': 'Bearer ' + accessToken
+		}
+	};
+
+	request(options, function(err, response, body) {
+        if (!err) {
+            var userDetails = JSON.parse(body);
+            callback(userDetails);
+		} else {
+            console.log(response.statusCode);
+			console.log('ERROR fetching client token: ' + err);
+		}
+	});
+};
+
+module.exports = getUserInfo;


### PR DESCRIPTION
Added a middleware that fetches user information from the UAA instance using the access token and adds it to the `request` object. 

Currently, the seed supports only login and authentication. Many applications require user information after SSO login. The middleware adds the access token to the header and makes a GET request to the `uaaURL/userinfo` endpoint.